### PR TITLE
Allow for continuous mode and non-blocking temp readings

### DIFF
--- a/DS1620.cpp
+++ b/DS1620.cpp
@@ -25,22 +25,27 @@ DS1620::DS1620(const int rst, const int clk, const int dq)
 }
 
 
-void DS1620::config()
+void DS1620::config(bool oneShot)
 {
   // Write configuration register in DS1620.
-  byte flags = FLAG_CPU | FLAG_1SHOT;
+  byte flags = FLAG_CPU;
+  if (oneShot) {
+    flags |= FLAG_1SHOT;
+  }
   write_command_8bit(write_config_, flags);
 
   // E^2 memory has a small write delay. According to the datasheet, this is
   // around 10ms at room temperature.
-  delay(50);
+  delay(30);
 }
 
 
-float DS1620::temp_c()
+float DS1620::temp_c(bool start)
 {
-  // Start temperature conversion.
-  start_conv();
+  if (start) {
+    // Start temperature conversion.
+    start_conv();
+  }
 
   start_transfer();
   write_data(read_temp_, eight_bits_);
@@ -66,12 +71,14 @@ float DS1620::temp_c()
 }
 
 
-void DS1620::start_conv()
+void DS1620::start_conv(bool wait)
 {
   write_command(start_conv_);
 
-  // Max conversion delay is 750ms according to the datasheet.
-  delay(750);
+  if (wait) {
+    // Max conversion delay is 750ms according to the datasheet.
+    delay(750);
+  }
 }
 
 

--- a/DS1620.h
+++ b/DS1620.h
@@ -53,17 +53,38 @@ class DS1620
   DS1620(int rst, int clk, int dq);
 
   /**
-   * Set up the DS1620 in CPU mode with 1-shot mode enabled.
+   * Set up the DS1620 in CPU mode.
+   * 
+   * Args:
+   *   oneShot: use 1-shot mode, or continuous mode otherwise
    */
-  void config();
+  void config(bool oneShot = true);
+
+  /**
+   * Trigger a temperature conversion in 1-shot mode, or enable continuous
+   * conversion.
+   * 
+   * Args:
+   *   wait: whether to wait using delay(750) (REQUIRED before the 1st
+   *         reading)
+   */
+  void start_conv(bool wait = true);
+
+  /**
+   * Disable continuous conversion.
+   */
+  void stop_conv();
 
   /**
    * Get the current temperature reading in Celsius.
    *
+   * Args:
+   *   start: whether to start themperature conversion before getting
+   *          the reading
    * Returns:
    *   temperature in degrees Celcius.
    */
-  float temp_c();
+  float temp_c(bool start = true);
 
  private:
   const int rst_pin_;
@@ -102,16 +123,6 @@ class DS1620
    * Resets pin levels after communication.
    */
   void end_transfer();
-
-  /**
-   * Trigger a temperature conversion in 1-shot mode, or enable continuous
-   * conversion.
-   */
-  void start_conv();
-  /**
-   * Disable continuous conversion.
-   */
-  void stop_conv();
 
   /**
    * Read data from the DS1602.


### PR DESCRIPTION
Makes it possible to use continuous mode by doing:
```
ds1620.config(false);
ds1620.start_conv();
for (int i=0; i<10; i++)
  float temp = temp_c();
ds1620.stop_conv();
```

Also enables us to use it in 1-shot non-blocking mode by calling `start_conv(false)` then checking inside our loop if 750ms has passed before calling `temp_c(false)`.